### PR TITLE
Use jo in outputting skipped messages

### DIFF
--- a/bin/check-skipped
+++ b/bin/check-skipped
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmp=$(mktemp)
+trap 'rm -f "$tmp"' EXIT
+
+cat >"$tmp" <<'EOM'
+Ignoring Restyle PR due to some error
+
+Lorem ipsum {dolor sit amet}, consectetur: adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+EOM
+
+docker run --rm \
+  --volume /tmp:/tmp:ro \
+  --entrypoint sh \
+  restyled/restyler:main -c "fold --width 72 --spaces '$tmp' | jo -d. level=info message.text=@-" | jq .

--- a/src/Restyled/Agent/Restyler.hs
+++ b/src/Restyled/Agent/Restyler.hs
@@ -106,8 +106,12 @@ dockerRunSkippedJob repo job messages = withSystemTempFile "" $ \tmp h -> do
     handleAny warn $ void $ runRestylerImage
         repo
         job
-        ["--entrypoint", "fold"]
-        ["--width", "72", "--spaces", pack tmp]
+        ["--entrypoint", "sh"]
+        [ "-c"
+        , "fold --width 72 --spaces '"
+        <> pack tmp
+        <> "' | jo -d. level=info message.text=@-"
+        ]
     pure ExitSuccess
   where
     formatMessages :: NonEmpty Text -> Text


### PR DESCRIPTION
This ensures they are JSON-structured logs and don't fall into DEBUG by
default, which are harder for users to see.
