### PR TITLE
Migrate to NoFieldSelectors and OverloadedRecordDot

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,36 @@
+- ignore: {name: "Use Just"}
+- ignore: {name: "Reduce duplication"}
+- ignore: {name: "Redundant do", within: spec}
+- ignore: {name: "Redundant ^."}
+- ignore: {name: "Use join"}
+- ignore: {name: "Use ++"}
+- ignore: {name: "Use &&"}
+- ignore: {name: "Use ||"}
+- ignore: {name: "Redundant id"}
+- arguments:
+  - -XBangPatterns
+  - -XDataKinds
+  - -XDeriveAnyClass
+  - -XDeriveFoldable
+  - -XDeriveFunctor
+  - -XDeriveGeneric
+  - -XDeriveLift
+  - -XDeriveTraversable
+  - -XDerivingStrategies
+  - -XFlexibleContexts
+  - -XFlexibleInstances
+  - -XGADTs
+  - -XGeneralizedNewtypeDeriving
+  - -XLambdaCase
+  - -XMultiParamTypeClasses
+  - -XNoFieldSelectors
+  - -XNoImplicitPrelude
+  - -XNoMonomorphismRestriction
+  - -XNoStaticPointers # Not used, but avoids reserved word issue
+  - -XOverloadedRecordDot
+  - -XOverloadedStrings
+  - -XRankNTypes
+  - -XScopedTypeVariables
+  - -XStandaloneDeriving
+  - -XTypeApplications
+  - -XTypeFamilies

--- a/agent.cabal
+++ b/agent.cabal
@@ -57,11 +57,12 @@ library
       GeneralizedNewtypeDeriving
       LambdaCase
       MultiParamTypeClasses
+      NoFieldSelectors
       NoImplicitPrelude
       NoMonomorphismRestriction
+      OverloadedRecordDot
       OverloadedStrings
       RankNTypes
-      RecordWildCards
       ScopedTypeVariables
       StandaloneDeriving
       TypeApplications
@@ -125,11 +126,12 @@ executable agent
       GeneralizedNewtypeDeriving
       LambdaCase
       MultiParamTypeClasses
+      NoFieldSelectors
       NoImplicitPrelude
       NoMonomorphismRestriction
+      OverloadedRecordDot
       OverloadedStrings
       RankNTypes
-      RecordWildCards
       ScopedTypeVariables
       StandaloneDeriving
       TypeApplications

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -13,13 +13,13 @@ main :: IO ()
 main = do
   options <- parseOptions
   withApp options $ do
-    case oLifecycleQueueUrl options of
+    case options.lifecycleQueueUrl of
       Nothing -> do
         void bootAgent
         logInfo "No Lifecycle Hook queue, running forever"
         forever $ threadDelay maxBound
       Just queue -> do
-        m <- oShutdownTimeoutMinutes <$> view optionsL
+        let m = options.shutdownTimeoutMinutes
         mAgent <- withPendingLifecycleHook queue bootAgent
         mmResult <- for mAgent $ \agent -> do
           withTerminatingLifecycleHook queue $ do

--- a/package.yaml
+++ b/package.yaml
@@ -33,11 +33,12 @@ default-extensions:
   - GeneralizedNewtypeDeriving
   - LambdaCase
   - MultiParamTypeClasses
+  - NoFieldSelectors
   - NoImplicitPrelude
   - NoMonomorphismRestriction
+  - OverloadedRecordDot
   - OverloadedStrings
   - RankNTypes
-  - RecordWildCards
   - ScopedTypeVariables
   - StandaloneDeriving
   - TypeApplications

--- a/src/GitHub/Data/AccessTokens.hs
+++ b/src/GitHub/Data/AccessTokens.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE FieldSelectors #-}
+
 module GitHub.Data.AccessTokens
   ( AccessToken (..)
   ) where

--- a/src/GitHub/Data/Apps.hs
+++ b/src/GitHub/Data/Apps.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE FieldSelectors #-}
+
 module GitHub.Data.Apps
   ( App
   , AppKey

--- a/src/GitHub/Data/Installations.hs
+++ b/src/GitHub/Data/Installations.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE FieldSelectors #-}
+{-# LANGUAGE RecordWildCards #-}
+
 module GitHub.Data.Installations
   ( Installation (..)
   ) where

--- a/src/GitHub/Data/PullRequests/Ext.hs
+++ b/src/GitHub/Data/PullRequests/Ext.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE FieldSelectors #-}
+{-# LANGUAGE RecordWildCards #-}
+
 -- | Extends "GitHub.Data.PullRequests" 'PullRequestEvent'
 module GitHub.Data.PullRequests.Ext
   ( PullRequestEvent (..)

--- a/src/GitHub/Endpoints/Installations/AccessTokens.hs
+++ b/src/GitHub/Endpoints/Installations/AccessTokens.hs
@@ -6,7 +6,7 @@ import Prelude
 
 import GitHub.Data
 import GitHub.Data.AccessTokens
-import GitHub.Data.Installations
+import GitHub.Data.Installations hiding (installationId)
 import GitHub.Request.Preview
 
 accessTokenForR :: Id Installation -> PreviewRequest 'RW AccessToken

--- a/src/Restyled/Agent.hs
+++ b/src/Restyled/Agent.hs
@@ -33,7 +33,7 @@ bootAgent
      )
   => m Agent
 bootAgent = do
-  size <- (.restylerPoolSize) <$> view optionsL
+  size <- views optionsL (.restylerPoolSize)
   Agent <$> traverse bootAgentThread [1 .. size]
 
 bootAgentThread

--- a/src/Restyled/Agent.hs
+++ b/src/Restyled/Agent.hs
@@ -19,8 +19,8 @@ newtype Agent = Agent
   }
 
 data Thread = Thread
-  { tLabel :: Text
-  , tThread :: Immortal.Thread
+  { label :: Text
+  , thread :: Immortal.Thread
   }
 
 bootAgent
@@ -33,7 +33,7 @@ bootAgent
      )
   => m Agent
 bootAgent = do
-  size <- oRestylerPoolSize <$> view optionsL
+  size <- (.restylerPoolSize) <$> view optionsL
   Agent <$> traverse bootAgentThread [1 .. size]
 
 bootAgentThread
@@ -92,10 +92,10 @@ shutdownAgent (Agent threads) = do
 
 shutdownAgentThread
   :: (MonadUnliftIO m, MonadLogger m) => Thread -> m (Async ())
-shutdownAgentThread Thread {..} = do
-  logInfo $ "mortalizing" :# ["thread" .= tLabel]
-  liftIO $ Immortal.mortalize tThread
+shutdownAgentThread thread = do
+  logInfo $ "mortalizing" :# ["thread" .= thread.label]
+  liftIO $ Immortal.mortalize thread.thread
 
   async $ do
-    liftIO $ Immortal.wait tThread
-    logInfo $ "done" :# ["thread" .= tLabel]
+    liftIO $ Immortal.wait thread.thread
+    logInfo $ "done" :# ["thread" .= thread.label]

--- a/src/Restyled/Agent/GitHub.hs
+++ b/src/Restyled/Agent/GitHub.hs
@@ -32,7 +32,7 @@ import GitHub.Endpoints.Installations.AccessTokens
 import GitHub.Request
 
 getGitHubAppToken :: MonadIO m => Id App -> AppKey -> Id Installation -> m Text
-getGitHubAppToken appId appKey installationId = liftIO $ do
+getGitHubAppToken appId appKey iId = liftIO $ do
   auth <- authJWTMax appId appKey
-  let req = accessTokenForR installationId
+  let req = accessTokenForR iId
   either throwIO (pure . atToken) =<< github auth req

--- a/src/Restyled/Agent/Options.hs
+++ b/src/Restyled/Agent/Options.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE RecordWildCards #-}
+
 module Restyled.Agent.Options
   ( Options (..)
   , HasOptions (..)
@@ -12,20 +14,20 @@ import Restyled.Agent.Options.Env
 import qualified Restyled.Agent.Redis as Redis
 
 data Options = Options
-  { oGitHubAppId :: GitHub.Id GitHub.App
-  , oGitHubAppKey :: GitHub.AppKey
-  , oRestyledHost :: Text
-  , oRestyledToken :: Text
-  , oInstance :: Text
-  , oLifecycleQueueUrl :: Maybe Text
-  , oLoggerSettings :: LogSettings
-  , oNet :: Maybe Text
-  , oStatsdHost :: Maybe String
-  , oStatsdPort :: Maybe Int
-  , oRedisConnectInfo :: Redis.ConnectInfo
-  , oRestyleQueue :: ByteString
-  , oRestylerPoolSize :: Natural
-  , oShutdownTimeoutMinutes :: Natural
+  { gitHubAppId :: GitHub.Id GitHub.App
+  , gitHubAppKey :: GitHub.AppKey
+  , restyledHost :: Text
+  , restyledToken :: Text
+  , instanceId :: Text
+  , lifecycleQueueUrl :: Maybe Text
+  , loggerSettings :: LogSettings
+  , net :: Maybe Text
+  , statsdHost :: Maybe String
+  , statsdPort :: Maybe Int
+  , redisConnectInfo :: Redis.ConnectInfo
+  , restyleQueue :: ByteString
+  , restylerPoolSize :: Natural
+  , shutdownTimeoutMinutes :: Natural
   }
 
 class HasOptions env where

--- a/src/Restyled/Agent/Options/CLI.hs
+++ b/src/Restyled/Agent/Options/CLI.hs
@@ -8,7 +8,7 @@ import Restyled.Agent.Prelude
 import Options.Applicative
 
 newtype OptionsCLI = OptionsCLI
-  { oNet :: Maybe Text
+  { net :: Maybe Text
   }
 
 parseCLI :: IO OptionsCLI

--- a/src/Restyled/Agent/Options/Env.hs
+++ b/src/Restyled/Agent/Options/Env.hs
@@ -11,19 +11,19 @@ import qualified Restyled.Agent.GitHub as GitHub
 import qualified Restyled.Agent.Redis as Redis
 
 data OptionsEnv = OptionsEnv
-  { oGitHubAppId :: GitHub.Id GitHub.App
-  , oGitHubAppKey :: GitHub.AppKey
-  , oRestyledHost :: Text
-  , oRestyledToken :: Text
-  , oInstance :: Text
-  , oLifecycleQueueUrl :: Maybe Text
-  , oLoggerSettings :: LogSettings
-  , oStatsdHost :: Maybe String
-  , oStatsdPort :: Maybe Int
-  , oRedisConnectInfo :: Redis.ConnectInfo
-  , oRestyleQueue :: ByteString
-  , oRestylerPoolSize :: Natural
-  , oShutdownTimeoutMinutes :: Natural
+  { gitHubAppId :: GitHub.Id GitHub.App
+  , gitHubAppKey :: GitHub.AppKey
+  , restyledHost :: Text
+  , restyledToken :: Text
+  , instanceId :: Text
+  , lifecycleQueueUrl :: Maybe Text
+  , loggerSettings :: LogSettings
+  , statsdHost :: Maybe String
+  , statsdPort :: Maybe Int
+  , redisConnectInfo :: Redis.ConnectInfo
+  , restyleQueue :: ByteString
+  , restylerPoolSize :: Natural
+  , shutdownTimeoutMinutes :: Natural
   }
 
 -- brittany-disable-next-binding

--- a/src/Restyled/Agent/Prelude.hs
+++ b/src/Restyled/Agent/Prelude.hs
@@ -13,6 +13,7 @@ import Data.Functor.Syntax as X ((<$$>))
 import Data.Text as X (pack, unpack)
 import Data.Time as X (UTCTime, diffUTCTime, getCurrentTime)
 import Data.Traversable as X (for)
+import GHC.Records as X
 import Lens.Micro.Platform as X
   ( Lens'
   , lens

--- a/src/Restyled/Agent/Prelude.hs
+++ b/src/Restyled/Agent/Prelude.hs
@@ -32,7 +32,7 @@ import UnliftIO.Concurrent as X (threadDelay)
 import UnliftIO.Exception as X (handleAny, throwIO, tryAny)
 import UnliftIO.Temporary as X (withSystemTempFile)
 
-views :: MonadReader a m => Lens' a b -> (b -> c) -> m c
+views :: MonadReader s m => Lens' s a -> (a -> r) -> m r
 views l f = f <$> view l
 
 eitherDecodeText :: FromJSON a => Text -> Either String a

--- a/src/Restyled/Agent/Prelude.hs
+++ b/src/Restyled/Agent/Prelude.hs
@@ -1,5 +1,6 @@
 module Restyled.Agent.Prelude
   ( module X
+  , views
   , eitherDecodeText
   , exitCodeInt
   ) where
@@ -30,6 +31,9 @@ import UnliftIO.Async as X (Async, async, race, wait)
 import UnliftIO.Concurrent as X (threadDelay)
 import UnliftIO.Exception as X (handleAny, throwIO, tryAny)
 import UnliftIO.Temporary as X (withSystemTempFile)
+
+views :: MonadReader a m => Lens' a b -> (b -> c) -> m c
+views l f = f <$> view l
 
 eitherDecodeText :: FromJSON a => Text -> Either String a
 eitherDecodeText = eitherDecode . fromStrict . encodeUtf8

--- a/src/Restyled/Agent/Queue.hs
+++ b/src/Restyled/Agent/Queue.hs
@@ -17,7 +17,7 @@ awaitWebhook
      )
   => m (Maybe a)
 awaitWebhook = do
-  queueName <- oRestyleQueue <$> view optionsL
+  queueName <- (.restyleQueue) <$> view optionsL
   eresult <- runRedis $ brpop [queueName] webhookTimeout
 
   case over _2 eitherDecodeStrict <$$> eresult of

--- a/src/Restyled/Agent/Queue.hs
+++ b/src/Restyled/Agent/Queue.hs
@@ -17,7 +17,7 @@ awaitWebhook
      )
   => m (Maybe a)
 awaitWebhook = do
-  queueName <- (.restyleQueue) <$> view optionsL
+  queueName <- views optionsL (.restyleQueue)
   eresult <- runRedis $ brpop [queueName] webhookTimeout
 
   case over _2 eitherDecodeStrict <$$> eresult of

--- a/src/Restyled/Api.hs
+++ b/src/Restyled/Api.hs
@@ -108,9 +108,9 @@ restyledRequest
   -> String
   -> m Request
 restyledRequest method path = do
-  (host, token) <- ((.restyledHost) &&& (.restyledToken)) <$> view optionsL
-  req <- liftIO $ parseRequest $ method <> " " <> unpack host <> path
-  pure $ addAuthorization token $ setRequestCheckStatus req
+  options <- view optionsL
+  req <- liftIO $ parseRequest $ method <> " " <> unpack options.host <> path
+  pure $ addAuthorization options.token $ setRequestCheckStatus req
  where
   addAuthorization :: Text -> Request -> Request
   addAuthorization token =

--- a/src/Restyled/Api.hs
+++ b/src/Restyled/Api.hs
@@ -109,8 +109,9 @@ restyledRequest
   -> m Request
 restyledRequest method path = do
   options <- view optionsL
-  req <- liftIO $ parseRequest $ method <> " " <> unpack options.host <> path
-  pure $ addAuthorization options.token $ setRequestCheckStatus req
+  req <-
+    liftIO $ parseRequest $ method <> " " <> unpack options.restyledHost <> path
+  pure $ addAuthorization options.restyledToken $ setRequestCheckStatus req
  where
   addAuthorization :: Text -> Request -> Request
   addAuthorization token =

--- a/src/Restyled/Api.hs
+++ b/src/Restyled/Api.hs
@@ -108,7 +108,7 @@ restyledRequest
   -> String
   -> m Request
 restyledRequest method path = do
-  (host, token) <- (oRestyledHost &&& oRestyledToken) <$> view optionsL
+  (host, token) <- ((.restyledHost) &&& (.restyledToken)) <$> view optionsL
   req <- liftIO $ parseRequest $ method <> " " <> unpack host <> path
   pure $ addAuthorization token $ setRequestCheckStatus req
  where

--- a/src/Restyled/Api/Job.hs
+++ b/src/Restyled/Api/Job.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE NamedFieldPuns #-}
-
 module Restyled.Api.Job
   ( ApiJob (..)
   , apiJobSpec
@@ -24,8 +22,12 @@ data ApiJob = ApiJob
   deriving anyclass (FromJSON, ToJSON)
 
 apiJobSpec :: ApiJob -> Text
-apiJobSpec ApiJob {owner, repo, pullRequest} =
-  toPathPart owner <> "/" <> toPathPart repo <> "#" <> toPathPart pullRequest
+apiJobSpec job =
+  toPathPart job.owner
+    <> "/"
+    <> toPathPart job.repo
+    <> "#"
+    <> toPathPart job.pullRequest
 
 newtype ApiJobId = ApiJobId
   { unApiJobId :: Int
@@ -33,4 +35,4 @@ newtype ApiJobId = ApiJobId
   deriving newtype (FromJSON, ToJSON)
 
 apiJobIdToText :: ApiJobId -> Text
-apiJobIdToText = pack . show . unApiJobId
+apiJobIdToText = pack . show . coerce @_ @Int


### PR DESCRIPTION
Big gotcha: `RecordWildCards` still works as before, as I expect
`NamedFieldPuns` could too. This can be useful, but having it enabled by
default can mean you miss lots of places you want to migrate to
`RecordDot` syntax. Better to disable it by default and then enable it
sparingly when useful (such as how we construct our options through
field-name sharing).
